### PR TITLE
Upgrade to ruby 2.4.5 and fixes for xar needing openssl 1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/ruby:2.3.4-node
+FROM circleci/ruby:2.4.5-node
 
 ENV XAR_VERSION "1.6.1"
 USER root

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# fastlane-docker
+
+A `Dockerfile` that is used on _fastlane_'s CIs which is configured for Ruby 2.4.5, Python 3.6.8, and Java 8.
+
+## Publishing a new version
+
+```
+docker build -t fastlanetools/ci:x.y.z ./
+docker push fastlanetools/ci:x.y.z
+```


### PR DESCRIPTION
- Bumped the circle ruby 2.4.5
- Moved `apt-get install` to the first thing since we need `libssl-dev`
- Using a fork of `xar` (under the fastlane org) that has a fix for openssl 1.1
  - https://github.com/fastlane/xar