### PR TITLE
fix: drop pipfile for uv only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,4 @@ jobs:
           docker run --rm fastlaneci:latest ruby --version
           docker run --rm fastlaneci:latest node --version
           docker run --rm fastlaneci:latest xar --version
-          docker run --rm fastlaneci:latest pip --version
-          docker run --rm fastlaneci:latest pipenv --version
           docker run --rm fastlaneci:latest uv --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,12 +55,6 @@ rm -rf ${BUILDDIR}
 COPY --from=ghcr.io/astral-sh/uv:0.6.6 /uv /bin/uv
 ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
-# Install pip & pipenv
-RUN wget --quiet https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py > /dev/null 2>&1 && \
-    python /tmp/get-pip.py && \
-    rm /tmp/get-pip.py && \
-    pip install pipenv
-
 USER circleci
 
 # Make xar


### PR DESCRIPTION
I removed pip from fastlane/docs so we can clean up this docker image - https://github.com/fastlane/docs/pull/1324